### PR TITLE
Laravel5/install: remove composer update

### DIFF
--- a/project/extend/v2/services/laravel5/install.sh
+++ b/project/extend/v2/services/laravel5/install.sh
@@ -10,12 +10,8 @@ laravel5Install() {
     wex site/start
   fi
 
-  # Composer install / update.
-  local ACTION="update"
-  if [ "${SITE_ENV}" = "prod" ];then
-    ACTION="install"
-  fi;
-  wex site/exec -l -c="composer "${ACTION}
+  # Composer install
+  wex site/exec -l -c="composer install"
 
   # Yarn
   local OPTION=""


### PR DESCRIPTION
Even in local or dev, just `composer install` ?

It seems preferable that all developers share the same versions, but please refuse the PR if necessary.