### PR TITLE
laravel: adding a cron/schedule:run sample

### DIFF
--- a/project/extend/v2/services/laravel5/samples/cron/prod
+++ b/project/extend/v2/services/laravel5/samples/cron/prod
@@ -1,1 +1,4 @@
 #* * * * * echo "Hello world" > /var/log/cron.log 2>&1
+
+# Run the Laravel's scheduler as www-data while outputing to /proc/1/fd/N as root
+#* * * * * su -s /bin/sh -c "cd /var/www/html/project && php artisan schedule:run" - www-data >/proc/1/fd/1 2>/proc/1/fd/2

--- a/project/extend/v2/services/laravel5/samples/cron/prod
+++ b/project/extend/v2/services/laravel5/samples/cron/prod
@@ -1,4 +1,6 @@
 #* * * * * echo "Hello world" > /var/log/cron.log 2>&1
 
 # Run the Laravel's scheduler as www-data while outputing to /proc/1/fd/N as root
+# This /proc/fd trick sends the logs to the docker engine, making it easy to follow:
+#  docker logs -f CONTAINER_ID
 #* * * * * su -s /bin/sh -c "cd /var/www/html/project && php artisan schedule:run" - www-data >/proc/1/fd/1 2>/proc/1/fd/2


### PR DESCRIPTION
This pull-request adds an example of launching `artisan schedule:run` as www-data while still outputing the result to docker's log (root needed).